### PR TITLE
Drop php 5.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "~7.0",
         "ext-crypto": "*",
         "guzzlehttp/guzzle": "~6.2.1",
         "mdanter/ecc": "~0.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "15b1481c8b33e92cc3a5c424794f4a77",
-    "content-hash": "0cc1540fe98a48f44701093fee3be7c2",
+    "hash": "f12c3f77e84508aa5f72b3f3e0af940e",
+    "content-hash": "1c23b6eaf5c85a6aaa21ba9b1b78c994",
     "packages": [
         {
             "name": "fgrosse/phpasn1",
@@ -78,16 +78,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.1",
+            "version": "6.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
                 "shasum": ""
             },
             "require": {
@@ -136,7 +136,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-07-15 17:22:37"
+            "time": "2016-10-08 15:01:37"
         },
         {
             "name": "guzzlehttp/promises",
@@ -363,16 +363,16 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
                 "shasum": ""
             },
             "require": {
@@ -400,6 +400,7 @@
                 }
             ],
             "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
             "keywords": [
                 "http",
                 "http-message",
@@ -408,7 +409,7 @@
                 "request",
                 "response"
             ],
-            "time": "2015-05-04 20:22:00"
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "spomky-labs/base64url",
@@ -470,7 +471,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~5.6|~7.0",
+        "php": "~7.0",
         "ext-crypto": "*"
     },
     "platform-dev": []

--- a/src/AggregatePushService.php
+++ b/src/AggregatePushService.php
@@ -29,7 +29,7 @@ class AggregatePushService implements PushService
      *
      * @return bool
      */
-    public function supportsHost($host)
+    public function supportsHost(string $host) : bool
     {
         $pushService = $this->pushServiceRegistry->getPushService($host);
 
@@ -45,7 +45,7 @@ class AggregatePushService implements PushService
      *
      * @throws UnsupportedPushMessageSubscription When the PushMessage Subscription has an unsupported endpoint.
      */
-    public function createRequest(PushMessage $message)
+    public function createRequest(PushMessage $message) : RequestInterface
     {
         $host = $message->getPushSubscription()->getEndpoint()->getHost();
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -42,7 +42,7 @@ class Client implements PushClient
      *
      * @return ResponseInterface
      */
-    public function pushNotification(PushNotification $notification, PushSubscription $subscription, $ttl = 3600)
+    public function pushNotification(PushNotification $notification, PushSubscription $subscription, int $ttl = 3600) : ResponseInterface
     {
         return $this->pushNotificationAsync($notification, $subscription, $ttl)->wait();
     }
@@ -56,7 +56,7 @@ class Client implements PushClient
      *
      * @return PromiseInterface
      */
-    public function pushNotificationAsync(PushNotification $notification, PushSubscription $subscription, $ttl = 3600)
+    public function pushNotificationAsync(PushNotification $notification, PushSubscription $subscription, int $ttl = 3600) : PromiseInterface
     {
         $cipher = $this->cryptograph->encrypt($notification, $subscription);
 

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -14,7 +14,7 @@ class Endpoint
      *
      * @param string $url
      */
-    public function __construct($url)
+    public function __construct(string $url)
     {
         $this->url = $url;
     }
@@ -24,7 +24,7 @@ class Endpoint
      *
      * @return string
      */
-    public function getUrl()
+    public function getUrl() : string
     {
         return $this->url;
     }
@@ -34,7 +34,7 @@ class Endpoint
      *
      * @return string
      */
-    public function getHost()
+    public function getHost() : string
     {
         return parse_url($this->url, PHP_URL_HOST);
     }
@@ -44,7 +44,7 @@ class Endpoint
      *
      * @return string
      */
-    public function getRegistrationId()
+    public function getRegistrationId() : string
     {
         preg_match('{^(\S+)(?:/)(?P<registrationId>[^/]+)}', $this->url, $matches);
 

--- a/src/GooglePushService.php
+++ b/src/GooglePushService.php
@@ -17,7 +17,7 @@ class GooglePushService implements PushService
      *
      * @param string $apiKey
      */
-    public function __construct($apiKey)
+    public function __construct(string $apiKey)
     {
         $this->apiKey = $apiKey;
     }
@@ -29,7 +29,7 @@ class GooglePushService implements PushService
      *
      * @return bool
      */
-    public function supportsHost($host)
+    public function supportsHost(string $host) : bool
     {
         return in_array($host, [
             'android.googleapis.com',
@@ -44,7 +44,7 @@ class GooglePushService implements PushService
      *
      * @return RequestInterface
      */
-    public function createRequest(PushMessage $message)
+    public function createRequest(PushMessage $message) : RequestInterface
     {
         $request = new Request(
             'POST',
@@ -63,7 +63,7 @@ class GooglePushService implements PushService
      *
      * @return string
      */
-    private function getUri(PushMessage $message)
+    private function getUri(PushMessage $message) : string
     {
         return 'https://fcm.googleapis.com/fcm/send/'.$message->getPushSubscription()->getEndpoint()->getRegistrationId();
     }
@@ -73,9 +73,9 @@ class GooglePushService implements PushService
      *
      * @param PushMessage $message
      *
-     * @return string
+     * @return string[]
      */
-    private function getHeaders(PushMessage $message)
+    private function getHeaders(PushMessage $message) : array
     {
         return [
             'Authorization' => 'key='.$this->apiKey,
@@ -95,7 +95,7 @@ class GooglePushService implements PushService
      *
      * @return string
      */
-    private function getBody(PushMessage $message)
+    private function getBody(PushMessage $message) : string
     {
         return $message->getBody();
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -21,7 +21,14 @@ class Message implements PushMessage
      */
     private $ttl;
 
-    public function __construct(Cipher $cipher, PushSubscription $subscription, $ttl = 3600)
+    /**
+     * Constructor.
+     *
+     * @param Cipher $cipher
+     * @param PushSubscription $subscription
+     * @param int $ttl
+     */
+    public function __construct(Cipher $cipher, PushSubscription $subscription, int $ttl = 3600)
     {
         $this->cipher = $cipher;
         $this->subscription = $subscription;
@@ -35,7 +42,7 @@ class Message implements PushMessage
      *
      * @return string
      */
-    public function getBody()
+    public function getBody() : string
     {
         return
             $this->cipher->getCipherText()->getRawBytes()
@@ -46,19 +53,19 @@ class Message implements PushMessage
     /**
      * Get cipher salt.
      *
-     * @return string
+     * @return string A url safe base64 encoded representation of the salt used.
      */
-    public function getSalt()
+    public function getSalt() : string
     {
         return $this->cipher->getSalt()->getBase64UrlSafeString();
     }
 
     /**
-     * Get cipher crypto key.
+     * Get the public key.
      *
-     * @return string
+     * @return string A url safe base64 encoded representation of the public key.
      */
-    public function getCryptoKey()
+    public function getCryptoKey() : string
     {
         return $this->cipher->getPublicKey()->getBase64UrlSafeString();
     }
@@ -68,7 +75,7 @@ class Message implements PushMessage
      *
      * @return int
      */
-    public function getContentLength()
+    public function getContentLength() : int
     {
         return strlen($this->getBody());
     }
@@ -78,7 +85,7 @@ class Message implements PushMessage
      *
      * @return PushSubscription
      */
-    public function getPushSubscription()
+    public function getPushSubscription() : PushSubscription
     {
         return $this->subscription;
     }
@@ -88,7 +95,7 @@ class Message implements PushMessage
      *
      * @return int
      */
-    public function getTTL()
+    public function getTTL() : int
     {
         return $this->ttl;
     }

--- a/src/MozillaPushService.php
+++ b/src/MozillaPushService.php
@@ -14,7 +14,7 @@ class MozillaPushService implements PushService
      *
      * @return bool
      */
-    public function supportsHost($host)
+    public function supportsHost(string $host) : bool
     {
         return in_array($host, [
             'updates.push.services.mozilla.com',
@@ -28,7 +28,7 @@ class MozillaPushService implements PushService
      *
      * @return RequestInterface
      */
-    public function createRequest(PushMessage $message)
+    public function createRequest(PushMessage $message) : RequestInterface
     {
         $request = new Request(
             'POST',
@@ -47,7 +47,7 @@ class MozillaPushService implements PushService
      *
      * @return string
      */
-    private function getUrl(PushMessage $message)
+    private function getUrl(PushMessage $message) : string
     {
         return $message->getPushSubscription()->getEndpoint()->getUrl();
     }
@@ -57,9 +57,9 @@ class MozillaPushService implements PushService
      *
      * @param PushMessage $message
      *
-     * @return string
+     * @return string[]
      */
-    private function getHeaders(PushMessage $message)
+    private function getHeaders(PushMessage $message) : array
     {
         return [
             'Content-Type' => 'application/json',
@@ -78,7 +78,7 @@ class MozillaPushService implements PushService
      *
      * @return string
      */
-    private function getBody(PushMessage $message)
+    private function getBody(PushMessage $message) : string
     {
         return $message->getBody();
     }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -32,7 +32,7 @@ class Notification implements PushNotification
      * @param string|null $url
      * @param string|null $icon
      */
-    public function __construct($title, $body, $url = null, $icon = null)
+    public function __construct(string $title, string $body, string $url = null, string $icon = null)
     {
         $this->title = $title;
         $this->body = $body;
@@ -55,7 +55,7 @@ class Notification implements PushNotification
      *
      * @return string
      */
-    public function json()
+    public function json() : string
     {
         return json_encode([
             'title' => $this->title,
@@ -70,7 +70,7 @@ class Notification implements PushNotification
      *
      * @return string
      */
-    public function getTitle()
+    public function getTitle() : string
     {
         return $this->title;
     }
@@ -80,7 +80,7 @@ class Notification implements PushNotification
      *
      * @return string
      */
-    public function getBody()
+    public function getBody() : string
     {
         return $this->body;
     }

--- a/src/PushClient.php
+++ b/src/PushClient.php
@@ -15,7 +15,7 @@ interface PushClient
      *
      * @return ResponseInterface
      */
-    public function pushNotification(PushNotification $notification, PushSubscription $subscription, $ttl = 3600);
+    public function pushNotification(PushNotification $notification, PushSubscription $subscription, int $ttl = 3600) : ResponseInterface;
 
     /**
      * Send a push notification asynchronously.
@@ -26,5 +26,5 @@ interface PushClient
      *
      * @return PromiseInterface
      */
-    public function pushNotificationAsync(PushNotification $notification, PushSubscription $subscription, $ttl = 3600);
+    public function pushNotificationAsync(PushNotification $notification, PushSubscription $subscription, int $ttl = 3600) : PromiseInterface;
 }

--- a/src/PushMessage.php
+++ b/src/PushMessage.php
@@ -11,40 +11,40 @@ interface PushMessage
      *
      * @return string
      */
-    public function getBody();
+    public function getBody() : string;
 
     /**
      * Get cipher salt.
      *
-     * @return string
+     * @return string A url safe base64 encoded representation of the salt used.
      */
-    public function getSalt();
+    public function getSalt() : string;
 
     /**
-     * Get cipher crypto key.
+     * Get the public key.
      *
-     * @return string
+     * @return string A url safe base64 encoded representation of the public key.
      */
-    public function getCryptoKey();
+    public function getCryptoKey() : string;
 
     /**
      * Get message content length.
      *
      * @return int
      */
-    public function getContentLength();
+    public function getContentLength() : int;
 
     /**
      * Get message subscription.
      *
      * @return PushSubscription
      */
-    public function getPushSubscription();
+    public function getPushSubscription() : PushSubscription;
 
     /**
      * Get message ttl.
      *
      * @return int
      */
-    public function getTTL();
+    public function getTTL() : int;
 }

--- a/src/PushNotification.php
+++ b/src/PushNotification.php
@@ -16,21 +16,21 @@ interface PushNotification
      *
      * @return string
      */
-    public function json();
+    public function json() : string;
 
     /**
      * Get the title.
      *
      * @return string
      */
-    public function getTitle();
+    public function getTitle() : string;
 
     /**
      * Get the body.
      *
      * @return string
      */
-    public function getBody();
+    public function getBody() : string;
 
     /**
      * Get the body.

--- a/src/PushService.php
+++ b/src/PushService.php
@@ -13,7 +13,7 @@ interface PushService
      *
      * @return bool
      */
-    public function supportsHost($host);
+    public function supportsHost(string $host) : bool;
 
     /**
      * Create a push request.
@@ -22,5 +22,5 @@ interface PushService
      *
      * @return RequestInterface
      */
-    public function createRequest(PushMessage $message);
+    public function createRequest(PushMessage $message) : RequestInterface;
 }

--- a/src/PushSubscription.php
+++ b/src/PushSubscription.php
@@ -12,19 +12,19 @@ interface PushSubscription
      *
      * @return Endpoint
      */
-    public function getEndpoint();
+    public function getEndpoint() : Endpoint;
 
     /**
      * Get the public key.
      *
      * @return PublicKey
      */
-    public function getPublicKey();
+    public function getPublicKey() : PublicKey;
 
     /**
      * Get the authentication tag.
      *
      * @return AuthenticationTag
      */
-    public function getAuthenticationTag();
+    public function getAuthenticationTag() : AuthenticationTag;
 }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -41,7 +41,7 @@ class Subscription implements PushSubscription
      *
      * @return Endpoint
      */
-    public function getEndpoint()
+    public function getEndpoint() : Endpoint
     {
         return $this->endpoint;
     }
@@ -51,7 +51,7 @@ class Subscription implements PushSubscription
      *
      * @return PublicKey
      */
-    public function getPublicKey()
+    public function getPublicKey() : PublicKey
     {
         return $this->publicKey;
     }
@@ -61,7 +61,7 @@ class Subscription implements PushSubscription
      *
      * @return AuthenticationTag
      */
-    public function getAuthenticationTag()
+    public function getAuthenticationTag() : AuthenticationTag
     {
         return $this->authenticationTag;
     }


### PR DESCRIPTION
Part 1 of some improvements i'm working on. Also working on specifications in phpspec, but felt like this could already be merged into master.

Didn't touch the crypto part yet. Leaving that for later when i've written specifications.

@peternijssen @flipspl Are you guys ok with dropping php 5.6? I realise it's a BC break but we aren't using php 5.6 anymore anyways. I would really like to have proper type declarations for all variables, not just objects.
